### PR TITLE
logical fix in ru_ru

### DIFF
--- a/languages/ru_ru.yml
+++ b/languages/ru_ru.yml
@@ -125,7 +125,7 @@ command:
         '5': Presti
     default: Открылось меню троллей!
     server: Инвентаризация серверных троллей открыта!
-    wrongargs: Пожалуйста, используйте неизвестные аргументы /troll help
+    wrongargs: Неверные аргументы! Для помощи по командам используйте: /troll help
     help:
       line:
         '8': '&4Troll Vanish &8- &c/troll v'


### PR DESCRIPTION
previously the message translated as "please use wrong arguments". updated it to: "wrong args! for help use /troll help"